### PR TITLE
docs: add standard issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,33 @@
+---
+name: Bug report
+about: Use this template for unexpected behavior, regressions, or failures
+title: "[Bug] Short summary"
+labels: bug
+assignees: chdenat
+---
+
+## Context
+
+Describe the current situation and where the bug occurs.
+
+## Requested behavior
+
+Describe the expected behavior.
+
+## Acceptance criteria
+
+- The bug is reproducible from a clear use case
+- The observed behavior is documented
+- The expected behavior is documented
+- The scope is limited to one bug per issue
+
+## Use case to reproduce the error
+
+- Action performed:
+- Expected result:
+- Actual result:
+- Reproducibility:
+
+## Technical notes
+
+Add logs, environment details, suspected root cause, or other technical context here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,2 @@
+blank_issues_enabled: false
+contact_links: []

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,29 @@
+---
+name: Feature request
+about: Use this template for new capabilities, improvements, or product changes
+title: "[Feature] Short summary"
+labels: enhancement
+assignees: chdenat
+---
+
+## Context
+
+Describe the current situation or the problem that needs to be solved.
+
+## Requested behavior
+
+Describe the behavior, outcome, or change that is expected.
+
+## Acceptance criteria
+
+- One criterion per bullet
+- Keep criteria observable and testable
+- Keep the scope limited to a single request
+
+## Notes or questions
+
+Add any relevant constraints, assumptions, or open questions here.
+
+## Technical notes
+
+Add implementation hints, dependencies, constraints, or other technical context here.

--- a/PROJECT_RULES.md
+++ b/PROJECT_RULES.md
@@ -59,3 +59,5 @@ This is the canonical source for the project's AI-agent and development rules.
 - **Complete fields:** Every created issue must have all available fields filled in, including title, description, assignee, labels, type, milestone, backlog, and any other fields required by the issue tracker.
 - **Assignee:** Assign the issue to the user requesting its creation unless the user explicitly specifies another assignee.
 - **Milestone and backlog:** Before creating an issue, ask the user which milestone and backlog it belongs to. Do not create the issue until both choices have been confirmed.
+- **Issue body structure:** Write every issue body in the same structure: short context, requested behavior, acceptance criteria, and optional notes or questions. Keep the scope to one request per issue and prefer bullet lists for requirements.
+- **Issue templates:** Use `.github/ISSUE_TEMPLATE/bug_report.md` for bugs and `.github/ISSUE_TEMPLATE/feature_request.md` for new features or improvements. Keep the sections consistent with the issue type and use the reproduction section only for bugs.


### PR DESCRIPTION
Add dedicated bug and feature issue templates under `.github/ISSUE_TEMPLATE/`.

Update `PROJECT_RULES.md` so new issues follow a consistent structure.

This PR does not include the version bump.