### PR TITLE
docs: sync issue types from templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -6,6 +6,8 @@ labels: bug
 assignees: chdenat
 ---
 
+<!-- issue-type: bug -->
+
 ## Context
 
 Describe the current situation and where the bug occurs.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -6,6 +6,8 @@ labels: enhancement
 assignees: chdenat
 ---
 
+<!-- issue-type: feature -->
+
 ## Context
 
 Describe the current situation or the problem that needs to be solved.

--- a/.github/scripts/sync-issue-type.mjs
+++ b/.github/scripts/sync-issue-type.mjs
@@ -1,0 +1,181 @@
+import { readFile } from 'node:fs/promises'
+
+/**
+ * Return a normalized lowercase issue-type name when the current issue body or labels identify one.
+ *
+ * @param {object} params - Detection input.
+ * @param {string} params.body - Issue body text.
+ * @param {Array<{ name?: string }>} params.labels - Issue labels from the webhook payload.
+ * @returns {string | null} The target issue type name, or null when no mapping applies.
+ */
+const getDesiredIssueTypeName = ({ body, labels }) => {
+  const markerMatch = body.match(/<!--\s*issue-type:\s*(bug|feature)\s*-->/i)
+
+  if (markerMatch) {
+    return markerMatch[1].toLowerCase()
+  }
+
+  const normalizedLabels = new Set(
+    labels.map((label) => (label.name ?? '').toLowerCase())
+  )
+
+  if (normalizedLabels.has('bug')) {
+    return 'bug'
+  }
+
+  if (normalizedLabels.has('enhancement')) {
+    return 'feature'
+  }
+
+  return null
+}
+
+/**
+ * Execute a GraphQL request against the GitHub API.
+ *
+ * @param {string} token - GitHub token used for authorization.
+ * @param {string} query - GraphQL query or mutation.
+ * @param {Record<string, unknown>} variables - GraphQL variables.
+ * @returns {Promise<any>} Parsed GraphQL response data.
+ */
+const graphqlRequest = async (token, query, variables) => {
+  const response = await fetch('https://api.github.com/graphql', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+      'User-Agent': 'lgs1920-issue-type-sync',
+    },
+    body: JSON.stringify({
+      query,
+      variables,
+    }),
+  })
+
+  const payload = await response.json()
+
+  if (!response.ok || payload.errors) {
+    const errorMessage = payload.errors
+      ? JSON.stringify(payload.errors)
+      : `HTTP ${response.status}`
+
+    throw new Error(`GitHub GraphQL request failed: ${errorMessage}`)
+  }
+
+  return payload.data
+}
+
+/**
+ * Sync the issue type from the issue template marker or labels.
+ *
+ * @returns {Promise<void>} Resolves when the issue type is synchronized.
+ */
+const main = async () => {
+  const event = JSON.parse(
+    await readFile(process.env.GITHUB_EVENT_PATH, 'utf8')
+  )
+
+  const issue = event.issue
+
+  if (!issue || issue.pull_request) {
+    console.log('No issue payload to process')
+    return
+  }
+
+  const token = process.env.GITHUB_TOKEN
+
+  if (!token) {
+    throw new Error('GITHUB_TOKEN is required')
+  }
+
+  const data = await graphqlRequest(
+    token,
+    `
+      query($owner: String!, $repo: String!, $number: Int!) {
+        repository(owner: $owner, name: $repo) {
+          issueTypes(first: 20) {
+            nodes {
+              id
+              name
+              isEnabled
+            }
+          }
+          issue(number: $number) {
+            id
+            issueType {
+              id
+              name
+            }
+          }
+        }
+      }
+    `,
+    {
+      owner: event.repository.owner.login,
+      repo: event.repository.name,
+      number: issue.number,
+    }
+  )
+
+  const repository = data.repository
+
+  if (!repository) {
+    throw new Error('Repository data is missing from the GraphQL response')
+  }
+
+  const desiredIssueTypeName = getDesiredIssueTypeName({
+    body: issue.body ?? '',
+    labels: issue.labels ?? [],
+  })
+
+  if (!desiredIssueTypeName) {
+    console.log('No issue type mapping found for this issue')
+    return
+  }
+
+  const issueType = repository.issueTypes.nodes.find((currentIssueType) => {
+    return (currentIssueType.name ?? '').toLowerCase() === desiredIssueTypeName
+  })
+
+  if (!issueType?.id) {
+    console.log(`Issue type ${desiredIssueTypeName} is not available`)
+    return
+  }
+
+  const currentIssueTypeName = repository.issue.issueType?.name?.toLowerCase() ?? null
+
+  if (currentIssueTypeName === desiredIssueTypeName) {
+    console.log(`Issue #${issue.number} already has type ${desiredIssueTypeName}`)
+    return
+  }
+
+  await graphqlRequest(
+    token,
+    `
+      mutation($issueId: ID!, $issueTypeId: ID!) {
+        updateIssueIssueType(input: { issueId: $issueId, issueTypeId: $issueTypeId }) {
+          issue {
+            id
+            issueType {
+              id
+              name
+            }
+          }
+        }
+      }
+    `,
+    {
+      issueId: repository.issue.id,
+      issueTypeId: issueType.id,
+    }
+  )
+
+  console.log(
+    `Set issue #${issue.number} type to ${desiredIssueTypeName}`
+  )
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exitCode = 1
+})

--- a/.github/workflows/sync-issue-type.yml
+++ b/.github/workflows/sync-issue-type.yml
@@ -1,0 +1,26 @@
+name: Sync issue type
+
+on:
+  issues:
+    types:
+      - opened
+      - reopened
+      - edited
+      - labeled
+
+permissions:
+  issues: write
+
+jobs:
+  sync-issue-type:
+    if: ${{ github.event.issue.pull_request == null }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Sync the issue type from the template marker
+        run: node .github/scripts/sync-issue-type.mjs
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/COMMIT_HISTORY.md
+++ b/COMMIT_HISTORY.md
@@ -1,5 +1,10 @@
 # Commit History
 
+## 2026-07-26 — [`docs: sync issue types from templates`](https://github.com/lgs1920/studio/commit/dcb2eeb0)
+
+- Add hidden issue-type markers to the bug and feature issue templates.
+- Add a GitHub Actions workflow and script that sync the repository issue type from the template marker or label fallback.
+
 ## 2026-07-25 — [`fix: throttle repeated codec error toasts`](https://github.com/lgs1920/studio/commit/3ef787f5)
 
 - Throttle repeated video codec error notifications to one toast every 30 seconds per recording session.

--- a/PROJECT_RULES.md
+++ b/PROJECT_RULES.md
@@ -61,3 +61,4 @@ This is the canonical source for the project's AI-agent and development rules.
 - **Milestone and backlog:** Before creating an issue, ask the user which milestone and backlog it belongs to. Do not create the issue until both choices have been confirmed.
 - **Issue body structure:** Write every issue body in the same structure: short context, requested behavior, acceptance criteria, and optional notes or questions. Keep the scope to one request per issue and prefer bullet lists for requirements.
 - **Issue templates:** Use `.github/ISSUE_TEMPLATE/bug_report.md` for bugs and `.github/ISSUE_TEMPLATE/feature_request.md` for new features or improvements. Keep the sections consistent with the issue type and use the reproduction section only for bugs.
+- **Issue type mapping:** When creating an issue from `bug_report.md`, set the GitHub issue type to `bug`. When creating an issue from `feature_request.md`, set the GitHub issue type to `feature`.

--- a/PROJECT_RULES.md
+++ b/PROJECT_RULES.md
@@ -61,4 +61,4 @@ This is the canonical source for the project's AI-agent and development rules.
 - **Milestone and backlog:** Before creating an issue, ask the user which milestone and backlog it belongs to. Do not create the issue until both choices have been confirmed.
 - **Issue body structure:** Write every issue body in the same structure: short context, requested behavior, acceptance criteria, and optional notes or questions. Keep the scope to one request per issue and prefer bullet lists for requirements.
 - **Issue templates:** Use `.github/ISSUE_TEMPLATE/bug_report.md` for bugs and `.github/ISSUE_TEMPLATE/feature_request.md` for new features or improvements. Keep the sections consistent with the issue type and use the reproduction section only for bugs.
-- **Issue type mapping:** When creating an issue from `bug_report.md`, set the GitHub issue type to `bug`. When creating an issue from `feature_request.md`, set the GitHub issue type to `feature`.
+- **Issue type mapping:** Each issue template must include its hidden `issue-type` marker, and the automation must set the GitHub issue type accordingly (`bug` for `bug_report.md`, `feature` for `feature_request.md`).


### PR DESCRIPTION
Add a GitHub Actions workflow that syncs the repository issue type from the issue template marker.

This extends the issue template work already merged into main and activates automatic type assignment for new issues.

The PR keeps the workflow scoped to issue events only.