### PR TITLE
docs: rename remaining tech-doc reference docs

### DIFF
--- a/COMMIT_HISTORY.md
+++ b/COMMIT_HISTORY.md
@@ -1,5 +1,11 @@
 # Commit History
 
+## 2026-07-26 — [`docs: rename provider and settings docs`](https://github.com/lgs1920/studio/commit/4325fd5b)
+
+- Rename the provider reference to `tech-doc/specs/HOW_TO_ADD_PROVIDERS_LAYERS.md`.
+- Rename the journey settings note to `tech-doc/specs/JOURNEY_SETTINGS_README.md`.
+- Update the technical documentation indexes and root README links to the new names.
+
 ## 2026-07-26 — [`docs: rename current docs to specs`](https://github.com/lgs1920/studio/commit/31fa0eaf)
 
 - Rename `tech-doc/current/` to `tech-doc/specs/` and move the dependency, provider, and sync guide references into the new specs tree.

--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ Tests are organized under `src/__tests__/` by responsibility:
 ## Configuration Notes
 
 - Application settings are primarily defined in `public/settings.yaml`
-- Map, overlay, and terrain providers are documented in [tech-doc/README_PROVIDERS.md](tech-doc/README_PROVIDERS.md)
+- Map, overlay, and terrain providers are documented in [tech-doc/specs/HOW_TO_ADD_PROVIDERS_LAYERS.md](tech-doc/specs/HOW_TO_ADD_PROVIDERS_LAYERS.md)
 - Widget registration is defined in `public/widgets.yaml`
 - PWA behavior is configured through `vite.config.ts` and `public/service-worker-pwa.js`
 - Static version metadata is stored in `public/version.json` and `public/build.json`
@@ -231,7 +231,7 @@ Tests are organized under `src/__tests__/` by responsibility:
 
 The root dependency documentation has been synchronized with the current `package.json`:
 
-- Full package inventory: [tech-doc/README_DEPENDENCIES.md](tech-doc/README_DEPENDENCIES.md)
+- Full package inventory: [tech-doc/specs/README_DEPENDENCIES.md](tech-doc/specs/README_DEPENDENCIES.md)
 - Build and runtime commands: [package.json](package.json)
 
 ## Contributing

--- a/tech-doc/README.md
+++ b/tech-doc/README.md
@@ -8,10 +8,9 @@ Proposed work, pending validation, or future implementation work lives under `to
 ## Specs
 
 - [Dependencies](specs/README_DEPENDENCIES.md)
-- [Providers](specs/README_PROVIDERS.md)
+- [Providers](specs/HOW_TO_ADD_PROVIDERS_LAYERS.md)
 - [Settings sync guide](specs/SETTINGS_SYNC_GUIDE.md)
-- [Provider list](PROVIDERS-LIST.md)
-- [Journey settings memo](JOURNEY_SETTINGS_MEMO.md)
+- [Journey settings readme](specs/JOURNEY_SETTINGS_README.md)
 - [Deployment](specs/DEPLOYMENT-README.md)
 - [Internal database architecture](specs/CORE-INTERNAL-DATABASE-ARCHITECTURE.md)
 - [Drone camera path architecture](specs/CORE-DRONE-CAMERA-PATH-ARCHITECTURE.md)

--- a/tech-doc/specs/HOW_TO_ADD_PROVIDERS_LAYERS.md
+++ b/tech-doc/specs/HOW_TO_ADD_PROVIDERS_LAYERS.md
@@ -1,4 +1,4 @@
-# Map Provider Configuration
+# How To Add Providers And Layers
 
 Map, overlay, terrain, and 3D providers are declared in `public/layers-terrains.yaml`.
 The file is loaded as runtime settings, indexed by `LayersAndTerrainManager`, and rendered by Cesium through

--- a/tech-doc/specs/JOURNEY_SETTINGS_README.md
+++ b/tech-doc/specs/JOURNEY_SETTINGS_README.md
@@ -1,4 +1,4 @@
-# Journey Settings Memo
+# Journey Settings README
 
 This note summarizes the `Journey` settings that matter for metrics, profile cleaning, and rendering.
 
@@ -162,4 +162,3 @@ For `bike`, the same shape usually needs looser values:
 ## Important rule
 
 Keep raw geometry untouched. The settings should clean the derived metrics and the rendered profile, not rewrite the source track data.
-

--- a/tech-doc/specs/README.md
+++ b/tech-doc/specs/README.md
@@ -5,8 +5,9 @@ This directory contains technical specifications and architecture documents that
 ## Reference docs
 
 - [Dependencies](README_DEPENDENCIES.md)
-- [Providers](README_PROVIDERS.md)
+- [Providers](HOW_TO_ADD_PROVIDERS_LAYERS.md)
 - [Settings sync guide](SETTINGS_SYNC_GUIDE.md)
+- [Journey settings readme](JOURNEY_SETTINGS_README.md)
 
 ## Deployment
 


### PR DESCRIPTION
What changed

- Renamed the provider reference doc to `tech-doc/specs/HOW_TO_ADD_PROVIDERS_LAYERS.md`.
- Renamed the journey settings note to `tech-doc/specs/JOURNEY_SETTINGS_README.md`.
- Updated the root README, technical documentation indexes, and commit history.

Why

- Keep the remaining tech-doc reference docs under the `specs/` hierarchy with clearer names.

Impact

- Provider and journey-settings documentation now follows the same moved-document pattern as the rest of `tech-doc/specs/`.

Validation

- `git diff --check`
