### PR TITLE
docs: add tech-doc naming rule

### DIFF
--- a/COMMIT_HISTORY.md
+++ b/COMMIT_HISTORY.md
@@ -1,5 +1,10 @@
 # Commit History
 
+## 2026-07-26 — [`docs: add tech-doc naming rule`](https://github.com/lgs1920/studio/commit/bf1fdfef)
+
+- Add an explicit naming rule for `tech-doc` documentation files in `PROJECT_RULES.md`.
+- Require uppercase, flat filenames with descriptive prefixes and no nested spec or todo document paths unless intentionally shared.
+
 ## 2026-07-26 — [`docs: rename provider and settings docs`](https://github.com/lgs1920/studio/commit/4325fd5b)
 
 - Rename the provider reference to `tech-doc/specs/HOW_TO_ADD_PROVIDERS_LAYERS.md`.

--- a/PROJECT_RULES.md
+++ b/PROJECT_RULES.md
@@ -43,6 +43,8 @@ This is the canonical source for the project's AI-agent and development rules.
 - Keep implementation documentation under `tech-doc/`.
 - Put specifications that are proposed, pending validation, explicitly TODO, or describe future implementation work under `tech-doc/todo/`.
 - Put specifications and architecture documents that describe the current implementation under `tech-doc/specs/`.
+- Name `tech-doc` documentation files with uppercase, flat filenames using descriptive module prefixes when relevant, for example `CORE-...`, `JOURNEY_...`, or `HOW_TO_...`
+- Avoid nested document paths inside `tech-doc/specs/` and `tech-doc/todo/` unless a document intentionally remains in a shared reference location.
 - Keep general reference documentation in its existing module path unless it is an implementation specification.
 - Update links in `README.md`, `tech-doc/README.md`, and nearby technical documents when moving a document.
 - Every change to documentation under `tech-doc/` must be delivered through a pull request and merged to `main`.


### PR DESCRIPTION
What changed

- Added an explicit `tech-doc` documentation naming rule to `PROJECT_RULES.md`.
- The rule requires uppercase flat filenames with descriptive prefixes and avoids nested spec or todo document paths unless intentionally shared.

Why

- Keep documentation names consistent as the technical documentation tree evolves.

Impact

- Future documentation moves will follow a clearer naming convention.

Validation

- `git diff --check`
