### PR TITLE
docs: require issue clarification and validation

### DIFF
--- a/COMMIT_HISTORY.md
+++ b/COMMIT_HISTORY.md
@@ -1,5 +1,10 @@
 # Commit History
 
+## 2026-07-28 — [`docs: require issue draft validation`](https://github.com/lgs1920/studio/commit/03ce0f44)
+
+- Require clarification of missing issue details before drafting an issue.
+- Require explicit user validation of the complete issue content before creation.
+
 ## 2026-07-28 — [`docs: update project rules`](https://github.com/lgs1920/studio/commit/f8b303ce)
 
 - Require project documentation and issue content to be written in English.

--- a/PROJECT_RULES.md
+++ b/PROJECT_RULES.md
@@ -61,6 +61,7 @@ This is the canonical source for the project's AI-agent and development rules.
 
 ## 6. Issue Creation Workflow
 
+- **Clarification and validation:** Before creating an issue, ask the user for any missing explanations or clarifications needed to understand and scope the request. Then present the complete proposed issue content for explicit user validation. Do not create the issue until the user has validated the proposal.
 - **Complete fields:** Every created issue must have all available fields filled in, including title, description, assignee, labels, type, milestone, backlog, and any other fields required by the issue tracker.
 - **Assignee:** Assign the issue to the user requesting its creation unless the user explicitly specifies another assignee.
 - **Milestone and backlog:** When the user does not specify a backlog, use `Backlog`. When the user does not specify a milestone, use the latest available milestone. The user will update these values afterward if needed.


### PR DESCRIPTION
## Summary

- Require clarification of missing information before creating an issue.
- Require presenting the complete proposed issue content for explicit user validation.
- Prevent issue creation until the proposal is validated.
- Record the project-rules commit in `COMMIT_HISTORY.md`.

## Why

Issue requests can be incomplete or ambiguous. The new workflow ensures that the scope and final issue content are reviewed before any issue is created.

## Validation

- `git diff --check HEAD~2..HEAD`
- Documentation-only change; no runtime tests were required.

## Scope

This PR is intentionally limited to the issue-creation workflow and its commit-history entry.