### PR TITLE
docs: synchronize project rules and release skill

### DIFF
--- a/.aiassistant/skills/lgs-1920-studio-release-changelog/SKILL.md
+++ b/.aiassistant/skills/lgs-1920-studio-release-changelog/SKILL.md
@@ -1,19 +1,66 @@
 ---
 name: lgs-1920-studio-release-changelog
-description: Prepare LGS1920 release notes, commit history entries, README updates, version validation, and release-ready documentation from implemented changes and closed issues.
+description: Prepare LGS1920 release changelogs, commit history entries, README updates, version validation, and release-ready documentation from implemented changes and repository issues.
 ---
 
-# Release Notes and Commit History
+# Release Changelog and Commit History
 
-Use this skill when preparing a commit, release, or commit history update. Inspect the current diff, existing README and commit history conventions, package version, and related tests first.
+Use this skill when preparing a release changelog, commit, or commit history update. Inspect the current diff, existing README and commit history conventions, package version, target release, repository issue data, and related tests first.
+
+## Changelog file and header rules
+
+- Store release files in `public/assets/changelog/`.
+- Use the exact filename `YYYYMMDD-<version>.md`. `YYYYMMDD` is the release date and `<version>` is the exact version, including prerelease identifiers. If the target file is absent, create it automatically with today's date; do not wait for a separate file-creation request.
+- Before creating a file, inspect the nearest existing changelog in the same release line. Preserve its heading level, title style, section spelling, and blank-line conventions. Existing historical files may use either `#` or `##`; new files must follow the closest applicable pattern rather than retroactively changing old files.
+- The first heading must identify the release and its user-facing theme. Use the established repository pattern, for example `## Replay, HQ Video Export, Widgets, and Map Providers`, followed by the release content. Do not add a generated date line unless the established pattern for the selected release line includes one.
+- Never overwrite an existing target changelog. Update it only when the user explicitly asks for a revision.
+
+## Issue source and ownership
+
+- Treat `studio`, `site`, and `backend` as separate issue repositories. Attribute each issue to the repository that owns it and link to that repository's issue URL.
+- Never create or use a mirror issue in `studio` for a `site` or `backend` issue. If legacy mirrors are found, list them separately as migration data; do not include their duplicate numbers in release notes.
+- For legacy cleanup, confirm the owning issue, remove references to the mirror from the owning issue and related documents, then delete only the confirmed mirror. Verify that no active issue still links to the deleted URL.
+- Do not invent issue numbers, repository ownership, release membership, issue state, or user-facing outcomes. When ownership or release membership is ambiguous, report it instead of guessing.
+
+## Changelog structure
+
+Use the following logical structure, adapting section titles to the nearest existing changelog:
+
+1. User-facing capabilities and improvements.
+2. Fixes and reliability.
+3. Closed issues, grouped by owning repository.
+4. Remaining bugs, grouped by owning repository.
+5. Remaining features, grouped by owning repository.
+6. Technical enhancements and existing resource links.
+
+For closed issues, render only repositories that have at least one issue:
+
+```markdown
+## Closed Issues
+
+### Studio
+
+- [#123](https://github.com/lgs1920/studio/issues/123) Issue title
+
+### Site
+
+- [#456](https://github.com/lgs1920/site/issues/456) Issue title
+```
+
+Apply the same repository grouping to `Remaining Bugs` and `Remaining Features`. Omit a repository heading and its entries when that repository has no issue in the category. Omit the category heading entirely when no repository has an issue in that category. Do not render empty headings, placeholder text, or empty lists.
+
+Use consistent repository labels (`Studio`, `Site`, `Backend`) and preserve the issue title's meaning while correcting only obvious formatting errors. Closed issues belong under the repository where they were closed; an issue moved between repositories must be listed using its final owning URL.
 
 Workflow:
 
-1. Group changes by user-facing capability, fixes, reliability, and technical maintenance.
-2. Describe outcomes clearly and avoid implementation-only noise unless it affects users or maintainers.
-3. Link closed issues using the repository's existing format and distinguish shipped features from known issues.
-4. Update the required project documentation and `COMMIT_HISTORY.md` with the current date, preserving existing sections.
-5. Check that wording matches the actual diff and that version or beta labels are consistent.
-6. Run relevant validation and report remaining uncommitted changes without altering unrelated work.
+1. Determine the exact target version and release date. Use today's date when creating a missing changelog file.
+2. Inspect the nearest existing changelog and create the target file if necessary, matching its filename and header conventions.
+3. Inspect the current diff and issue data from `studio`, `site`, and `backend`. Separate shipped outcomes, closed issues, remaining bugs, and remaining features.
+4. Group every issue by owning repository and apply the conditional-heading rules above.
+5. Group changes by user-facing capability, fixes, reliability, and technical maintenance. Describe outcomes clearly and avoid implementation-only noise unless it affects users or maintainers.
+6. Link issues using their owning repository URLs and distinguish shipped features from remaining issues. Never include mirror issue links.
+7. Update the required project documentation and `COMMIT_HISTORY.md` with the current date, preserving existing sections.
+8. Check that wording matches the actual diff, issue state, repository ownership, and version or beta labels.
+9. Run relevant validation and report remaining uncommitted changes without altering unrelated work.
 
 Do not invent features, issue numbers, dates, or compatibility claims. Follow the repository commit key format when a commit is explicitly requested.

--- a/PROJECT_RULES.md
+++ b/PROJECT_RULES.md
@@ -59,17 +59,51 @@ This is the canonical source for the project's AI-agent and development rules.
 - **Commit history:** `COMMIT_HISTORY.md` when preparing a commit.
 - **Commit history entry:** Record every commit in `COMMIT_HISTORY.md` with its date, exact commit message, and a GitHub link in the format `https://github.com/lgs1920/studio/commit/<commit-id>`.
 
-## 6. Issue Creation Workflow
+## 6. Issue Management Workflow
 
 - **Clarification and validation:** Before creating an issue, ask the user for any missing explanations or clarifications needed to understand and scope the request. Then present the complete proposed issue content for explicit user validation. Do not create the issue until the user has validated the proposal.
-- **Complete fields:** Every created issue must have all available fields filled in, including title, description, assignee, labels, type, milestone, backlog, and any other fields required by the issue tracker.
+- **Solution and implementation plan:** For every issue, propose a solution and an implementation plan for explicit user validation. Do not create or implement the issue until the proposed solution and plan have been validated.
+- **Complete fields:** Every created issue must have all known and applicable fields filled in, including title, description, assignee, labels, type, priority, repository, Project status, and `Target release`. Do not invent a release, label, priority, or other value when the information is not known.
 - **Assignee:** Assign the issue to the user requesting its creation unless the user explicitly specifies another assignee.
-- **Milestone and backlog:** When the user does not specify a backlog, use `Backlog`. When the user does not specify a milestone, use the latest available milestone. The user will update these values afterward if needed.
+- **Release planning:** Use the Project-level `Target release` field as the source of truth for release planning across repositories. Use `Unplanned` when no approved release has been selected. Add a new target-release option only after the release has been approved.
+- **Milestone migration:** A milestone is not required for a new issue when `Target release` is known. For an existing issue with a milestone, copy the exact milestone title to the matching `Target release` option when one exists. Keep the milestone during the migration until the result and dependent reporting have been reviewed. Do not clear or delete milestones automatically, and report any mismatch or conflict.
+- **Backlog status:** Use the Project `Status` value `Backlog` for accepted work that is not ready to start. Do not treat backlog as a release field or encode versions in labels or statuses when `Target release` already provides that information.
 - **Issue body structure:** Write every issue body in the same structure: short context, requested behavior, acceptance criteria, and optional notes or questions. Keep the scope to one request per issue and prefer bullet lists for requirements.
 - **Issue templates:** Use `.github/ISSUE_TEMPLATE/bug_report.md` for bugs and `.github/ISSUE_TEMPLATE/feature_request.md` for new features or improvements. Keep the sections consistent with the issue type and use the reproduction section only for bugs.
 - **Issue type mapping:** Each issue template must include its hidden `issue-type` marker, and the automation must set the GitHub issue type accordingly (`bug` for `bug_report.md`, `feature` for `feature_request.md`).
-- **Cross-repository issue mirroring:** Every open issue in `lgs1920/site` and `lgs1920/backend` must have a corresponding issue in `lgs1920/studio`.
-- **Mirror title and label:** Prefix the Studio mirror title with `[Site]` or `[Backend]` and apply the matching lowercase `site` or `backend` label.
-- **Mirror type:** The Studio mirror must use the same GitHub issue type as the source issue. If the source issue has no type, determine and set its correct type before creating the mirror.
-- **Reciprocal links:** Add a cross-reference in both the source issue and its Studio mirror.
-- **Duplicate prevention:** Before creating a mirror, search open and closed Studio issues for an existing reference to the source issue and reuse the existing mirror when one exists.
+
+### Cross-repository issue ownership
+
+- The managed repositories are `studio`, `site`, and `backend`. Create an issue in the repository that owns the code, documentation, or operational change.
+- Never mirror a `site` or `backend` issue into `studio`. Cross-repository dependencies must be recorded with direct links in the original issue bodies, pull requests, or project fields; they must not be represented by duplicate issues.
+- During the mirror-removal migration, inventory every `studio` issue that exists only as a mirror of a `site` or `backend` issue. Before deleting a mirror, transfer any information that is not already present to the owning issue, remove every link to the mirror from the original issue and related project documentation, and verify that the owning issue remains linked to the correct pull request and Project item.
+- Delete only confirmed mirror issues. Do not delete an issue that owns work, has independent acceptance criteria, or cannot be mapped unambiguously to an owning `site` or `backend` issue. Report ambiguous cases for explicit user decision.
+- After the migration, verify that creating a `site` or `backend` issue produces no `studio` issue and that no active issue body links to a deleted mirror.
+
+### Project workflow statuses
+
+Use the shared organization Project and keep its `Status` field limited to the delivery workflow:
+
+New issues start in `Triage` unless their validated scope already justifies a different workflow state.
+
+- `Triage`: new work that needs clarification, ownership, or prioritization.
+- `Backlog`: accepted work that is not ready to start.
+- `Ready`: scoped work with acceptance criteria and a target release.
+- `In Progress`: active implementation.
+- `Review`: a linked pull request is open.
+- `QA`: review is approved and validation is in progress.
+- `Blocked`: an explicit dependency or decision prevents progress.
+- `Done`: the linked pull request is merged and the work is complete.
+
+Move an issue to `Review` when its pull request opens, to `QA` after review approval, and to `Done` only after merge. Add every implementation issue to the Project and link it to its pull request.
+
+Keep one shared Project across releases. Do not create a Project or a workflow status for each version. Preserve historical views, milestones, tags, and branches unless the user explicitly approves their removal.
+
+## 7. Release Changelog Workflow
+
+- Changelogs are stored in `public/assets/changelog/` and use the filename `YYYYMMDD-<version>.md`, where `YYYYMMDD` is the release date and `<version>` is the exact package/release version, including prerelease suffixes such as `1.0.0-beta.3`.
+- When the target changelog does not exist, create it automatically using today's date and the naming/header convention of the closest existing changelog for the same release line. Never overwrite an existing changelog merely to normalize its historical formatting.
+- Group closed issues under the repository that owns each issue: `studio`, `site`, or `backend`. Omit a repository heading when that repository has no closed issue for the release.
+- Group remaining open issues into separate bug and feature sections, again by repository. Omit both the repository heading and its entries when that repository has no issue in the category. Omit the category heading when no repository has an issue in that category.
+- Keep issue links pointing to the owning repository. Do not add links to mirror issues.
+- Do not invent issue numbers, release versions, dates, fixes, features, or known issues. Preserve the existing `Resources`, `Feature Backlog`, and `Known Issues` conventions unless the target release explicitly changes them.


### PR DESCRIPTION
## Summary

- synchronize cross-repository issue ownership rules
- document mirror cleanup without duplicate issues
- standardize shared changelog naming, formatting, and conditional issue sections

## Validation

- git diff --check
- scoped documentation-only change

Unrelated working-tree changes were kept out of this branch.