### PR TITLE
feat: automate commit history updates

### DIFF
--- a/.github/workflows/update-commit-history.yml
+++ b/.github/workflows/update-commit-history.yml
@@ -1,0 +1,43 @@
+name: Update commit history
+
+on:
+  push:
+    branches:
+      - '**'
+
+permissions:
+  contents: write
+
+concurrency:
+  group: update-commit-history-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  update:
+    if: github.ref_type == 'branch' && github.actor != 'github-actions[bot]'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out the pushed branch
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Update commit history
+        run: bun run commit-history:update
+
+      - name: Commit and push history updates
+        run: |
+          if git diff --quiet -- COMMIT_HISTORY.md; then
+            echo "COMMIT_HISTORY.md is already up to date"
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add COMMIT_HISTORY.md
+          git commit -m "docs: update commit history"
+          git push origin "HEAD:${GITHUB_REF_NAME}"

--- a/COMMIT_HISTORY.md
+++ b/COMMIT_HISTORY.md
@@ -511,3 +511,31 @@
 ## 2026-08-04 — [`docs: add beta.4 changelog`](https://github.com/lgs1920/studio/commit/536b4450)
 
 - Add the 1.0.0-beta.4 release changelog with Studio and Backend closed issues, resources, feature backlog, and known issues.
+
+## 2026-08-03 — [`docs: record project rules changelog rule commit`](https://github.com/lgs1920/studio/commit/ceeb1356489eccc8cf6886380a828f0159af5570)
+
+- Recorded automatically from Git history.
+
+## 2026-08-03 — [`Merge pull request #451 from lgs1920/agent/project-rules-site-backend-changelog`](https://github.com/lgs1920/studio/commit/013dfce50c04e082275b44af2ef7b7fb33a0a51a)
+
+- docs: include site and backend issue history in changelogs
+
+## 2026-08-04 — [`docs: record beta.4 changelog commit`](https://github.com/lgs1920/studio/commit/48b252eedc6d75b3119a00cc686a29323a52c74b)
+
+- Recorded automatically from Git history.
+
+## 2026-08-04 — [`Merge branch 'main' into 1.0.0-beta.4`](https://github.com/lgs1920/studio/commit/d1b7f42d3c3883dd40fdea40ebb233009e1b807d)
+
+- Recorded automatically from Git history.
+
+## 2026-08-04 — [`Merge pull request #453 from lgs1920/1.0.0-beta.4`](https://github.com/lgs1920/studio/commit/c78d4aa59703e89c876107fbdeb35c762c75b9e1)
+
+- 1.0.0 beta.4
+
+## 2026-08-04 — [`feat(automation): update commit history after pushes`](https://github.com/lgs1920/studio/commit/90aeedcdc8c01273248557f3c1cb1b52f630cd69)
+
+- Recorded automatically from Git history.
+
+## 2026-08-04 — [`docs: automate commit history rule`](https://github.com/lgs1920/studio/commit/8ba13eef9efdd98c358fa06e437b32407ed1e28d)
+
+- Recorded automatically from Git history.

--- a/PROJECT_RULES.md
+++ b/PROJECT_RULES.md
@@ -56,8 +56,8 @@ This is the canonical source for the project's AI-agent and development rules.
 - **Commit Logic:** Never create commits automatically. Only create a commit when the user explicitly requests it. Do not stage or commit proactively on your own initiative.
 - **Project rules changes:** Every modification to `PROJECT_RULES.md` must be isolated in a dedicated commit, submitted through a dedicated pull request, and merged into `main`.
 - **Dependency inventory:** When a commit changes `package.json` dependencies or dependency-related credits, update `tech-doc/specs/README_DEPENDENCIES.md` in the same change set if the inventory is still meant to mirror the current package list.
-- **Commit history:** `COMMIT_HISTORY.md` when preparing a commit.
-- **Commit history entry:** Record every commit in `COMMIT_HISTORY.md` with its date, exact commit message, and a GitHub link in the format `https://github.com/lgs1920/studio/commit/<commit-id>`.
+- **Commit history:** `COMMIT_HISTORY.md` is updated automatically by the `Update commit history` GitHub workflow after pushes to branches.
+- **Commit history entry:** The workflow records every previously undocumented commit with its date, exact commit message, and a GitHub link in the format `https://github.com/lgs1920/studio/commit/<commit-id>`. The generated `docs: update commit history` commit is excluded from its own history update.
 
 ## 6. Issue Management Workflow
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "dev": "bunx --bun vite --mode development",
     "build": "bun run test:stores && bunx --bun vite build",
+    "commit-history:update": "bun scripts/update-commit-history.mjs",
     "deploy": "bun deploy.js",
     "lint": "oxlint . --type-aware --report-unused-disable-directives-severity error",
     "logo:export": "bun scripts/logo-tool.mjs export",

--- a/scripts/update-commit-history.mjs
+++ b/scripts/update-commit-history.mjs
@@ -1,0 +1,160 @@
+import {execFileSync} from 'node:child_process'
+import {readFileSync, writeFileSync} from 'node:fs'
+import {resolve} from 'node:path'
+
+const HISTORY_COMMIT_MESSAGE = 'docs: update commit history'
+const GITHUB_REPOSITORY = process.env.GITHUB_REPOSITORY ?? 'lgs1920/studio'
+const GITHUB_SERVER_URL = process.env.GITHUB_SERVER_URL ?? 'https://github.com'
+
+/**
+ * Executes a Git command from the repository root.
+ *
+ * @param {string[]} argumentsList Git command arguments.
+ * @param {string} repositoryRoot Absolute repository root path.
+ * @returns {string} Trimmed Git command output.
+ */
+const runGit = (argumentsList, repositoryRoot) => execFileSync('git', argumentsList, {
+    cwd: repositoryRoot,
+    encoding: 'utf8',
+}).trim()
+
+/**
+ * Reads all commit identifiers already documented in the history file.
+ *
+ * @param {string} historyContent Existing history file content.
+ * @returns {Set<string>} Recorded commit identifiers.
+ */
+const getRecordedHashes = historyContent => new Set(
+    [...historyContent.matchAll(/\/commit\/([0-9a-f]+)/gi)].map(match => match[1].toLowerCase()),
+)
+
+/**
+ * Reads the commit identifier from the latest history entry.
+ *
+ * @param {string} historyContent Existing history file content.
+ * @returns {string|null} Latest recorded commit identifier.
+ */
+const getLatestRecordedHash = historyContent => {
+    const matches = [...historyContent.matchAll(/\/commit\/([0-9a-f]+)/gi)]
+    return matches.at(-1)?.[1]?.toLowerCase() ?? null
+}
+
+/**
+ * Determines whether a commit hash is represented by an exact or abbreviated history link.
+ *
+ * @param {string} commitHash Full commit hash.
+ * @param {Set<string>} recordedHashes Commit identifiers found in the history file.
+ * @returns {boolean} Whether the commit is already recorded.
+ */
+const isRecorded = (commitHash, recordedHashes) => [...recordedHashes].some(recordedHash => (
+    commitHash.startsWith(recordedHash) || recordedHash.startsWith(commitHash)
+))
+
+/**
+ * Reads reachable commits in chronological order.
+ *
+ * @param {string} repositoryRoot Absolute repository root path.
+ * @param {string|null} sinceHash Latest recorded commit identifier.
+ * @returns {Array<{hash: string, date: string, subject: string, body: string}>} Reachable commits.
+ */
+const getCommits = (repositoryRoot, sinceHash) => {
+    const output = runGit([
+        'log',
+        '--reverse',
+        '--format=%H%x00%cs%x00%s%x00%b%x00',
+        sinceHash ? `${sinceHash}..HEAD` : 'HEAD',
+    ], repositoryRoot)
+
+    const fields = output.split('\0')
+    const commits = []
+
+    for (let index = 0; index + 3 < fields.length; index += 4) {
+        const [rawHash, rawDate, rawSubject, rawBody] = fields.slice(index, index + 4)
+        const hash = rawHash.trim()
+        const date = rawDate.trim()
+        const subject = rawSubject.trim()
+        const body = rawBody.trim()
+
+        if (hash && date && subject) {
+            commits.push({hash, date, subject, body})
+        }
+    }
+
+    return commits
+}
+
+/**
+ * Converts a commit body into the bullet format used by the history file.
+ *
+ * @param {string} body Commit body.
+ * @returns {string} Markdown bullet list.
+ */
+const formatDescription = body => {
+    const lines = body
+        .trim()
+        .split(/\r?\n/)
+        .map(line => line.trim())
+        .filter(Boolean)
+
+    if (lines.length === 0) {
+        return '- Recorded automatically from Git history.'
+    }
+
+    return lines
+        .map(line => line.startsWith('- ') ? line : `- ${line}`)
+        .join('\n')
+}
+
+/**
+ * Builds a history entry for a Git commit.
+ *
+ * @param {{hash: string, date: string, subject: string, body: string}} commit Git commit metadata.
+ * @returns {string} Markdown history entry.
+ */
+const buildEntry = commit => {
+    const commitUrl = `${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/commit/${commit.hash}`
+
+    return [
+        `## ${commit.date} — [\`${commit.subject}\`](${commitUrl})`,
+        '',
+        formatDescription(commit.body),
+    ].join('\n')
+}
+
+/**
+ * Updates the history file with all reachable, undocumented commits.
+ *
+ * @param {boolean} checkOnly Whether to report missing entries without writing the file.
+ * @returns {number} Process exit code.
+ */
+const updateHistory = checkOnly => {
+    const repositoryRoot = runGit(['rev-parse', '--show-toplevel'], process.cwd())
+    const historyPath = resolve(repositoryRoot, 'COMMIT_HISTORY.md')
+    const historyContent = readFileSync(historyPath, 'utf8')
+    const recordedHashes = getRecordedHashes(historyContent)
+    const latestRecordedHash = getLatestRecordedHash(historyContent)
+    const missingCommits = getCommits(repositoryRoot, latestRecordedHash).filter(commit => (
+        commit.subject !== HISTORY_COMMIT_MESSAGE && !isRecorded(commit.hash, recordedHashes)
+    ))
+
+    if (missingCommits.length === 0) {
+        console.log('COMMIT_HISTORY.md is up to date')
+        return 0
+    }
+
+    console.log(`Found ${missingCommits.length} undocumented commit(s)`)
+
+    if (checkOnly) {
+        missingCommits.forEach(commit => console.log(`- ${commit.hash} ${commit.subject}`))
+        return 1
+    }
+
+    const entries = missingCommits.map(buildEntry).join('\n\n')
+    const nextContent = `${historyContent.trimEnd()}\n\n${entries}\n`
+
+    writeFileSync(historyPath, nextContent)
+    return 0
+}
+
+const checkOnly = process.argv.includes('--check')
+process.exitCode = updateHistory(checkOnly)


### PR DESCRIPTION
## Summary

- Add a Bun script to detect and record commits missing from COMMIT_HISTORY.md.
- Run the update automatically after branch pushes through GitHub Actions.
- Update the project rule and isolate that rule change in its own commit.

## Validation

- Bun script check mode exercised against the main baseline.
- Oxlint passed for the automation script.
- GitHub Actions update workflow passed on the source branch.